### PR TITLE
fix: run post processing endpoints only if failed before 'Run agent'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,7 @@ runs:
         fi
 
     - name: Run agent
+      id: run_agent
       shell: bash
       run: wopee_agent
 
@@ -104,19 +105,13 @@ runs:
       run: |
         echo $WOPEE_AGENT_REPORT
 
-    - name: Confirm end of run
-      if: always()
+    - name: Post-process suites if agent did not run
+      if: failure() && steps.run_agent.outcome == 'skipped'
       shell: bash
       run: |
-
-        ERROR_FLAG=false
-        if [ "${{ job.status }}" = "failure" ]; then
-          ERROR_FLAG=true
-        fi
-
+        ERROR_FLAG=true
 
         if [ "${{ github.event.action }}" = "crawl" ]; then
-
           JSON_PAYLOAD=$(cat <<-EOF
           {
             "query": "mutation PostProcessAnalysisSuite(\$input: PostProcessAnalysisSuiteInput!) { postProcessAnalysisSuite(input: \$input) }",
@@ -130,9 +125,7 @@ runs:
           }
         EOF
           )
-
         else
-
           JSON_PAYLOAD=$(cat <<-EOF
           {
             "query": "mutation PostProcessAgentSuite(\$input: PostProcessAgentSuiteInput!) { postProcessAgentSuite(input: \$input) }",


### PR DESCRIPTION
Both post processing routes have been moved to agent's code base. Let's use them as a failsafe mechanism inside action in case step to run agent has not been initiated in order to stop in progress suites on CMD without user's intervention.