### PR TITLE
fix: bump checkout/upload-artifact to v5 for Node.js 24 support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: "[diag] Snapshot WOPEE_ env vars and runtime image"
       shell: bash
@@ -332,7 +332,7 @@ runs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: playwright-results
         path: |


### PR DESCRIPTION
## Summary

- Bump `actions/checkout@v4` → `v5` and `actions/upload-artifact@v4` → `v5` in [action.yml](action.yml).
- Both v5 releases run on Node.js 24, which becomes the default for self-hosted/runner-managed Node actions on **June 2, 2026**; Node 20 is removed entirely on **September 16, 2026** ([GitHub blog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
- Resolves the deprecation warning surfaced on `crawl` runs in consumer repos (e.g. `Wopee-io-DEV/playwright-template`).

<img width="1345" height="261" alt="image" src="https://github.com/user-attachments/assets/f82b0714-e767-4156-b53f-fed1ce6a248b" />


## Test plan

- [ ] Trigger a `crawl` run in a downstream project pinned to `Wopee-io/run-agent@v1` after this lands on `v1` and confirm the deprecation banner is gone.
- [ ] Confirm checkout still succeeds with no parameters (drop-in for our usage).
- [ ] Confirm artifact upload still produces `playwright-results` with the expected paths and `retention-days: 1`.