### PR TITLE
fix: bump checkout v5→v6 and upload-artifact v5→v7 (Node.js 24)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: "[diag] Snapshot WOPEE_ env vars and runtime image"
       shell: bash
@@ -332,7 +332,7 @@ runs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: playwright-results
         path: |


### PR DESCRIPTION
## Summary

Follow-up to #12. The previous bump (`@v4 → @v5` for both actions) did not clear the Node.js 20 deprecation warning because **`actions/upload-artifact@v5` still ships on Node 20** (`runs.using: node20` in its [action.yml](https://github.com/actions/upload-artifact/blob/v5/action.yml)). Only `v6` and `v7` moved to Node 24.

This PR:

- `actions/upload-artifact@v5` → **`@v7`** (current latest, released 2026-04-10; on `node24`).
- `actions/checkout@v5` → **`@v6`** (current latest, released 2026-01-09; already on `node24` — bumping while we're here for the `persist creds to a separate file` hardening from [#2286](https://github.com/actions/checkout/pull/2286)).

## Heads-up: upload-artifact v7 default changes

`actions/upload-artifact@v7` changed two defaults vs. `v4`/`v5`:
- `include-hidden-files` is now **`true`** (was `false`).
- `compression-level` defaults to **`0`** (store, no zip — faster, larger).

Our usage uploads `playwright-results` with `retention-days: 1` and no hidden files in the tree, so neither default should affect output. If results balloon in size, pin `compression-level: 6` explicitly.

## Test plan

- [ ] Trigger a `crawl` run in a downstream repo pinned to `Wopee-io-DEV/run-agent@v1` after this lands and confirm the deprecation banner is gone.
- [ ] Confirm `playwright-results` artifact still appears with the expected paths.