### PR TITLE
chore(interactive): upload chrome/proxy/socat stdout logs as artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -474,6 +474,11 @@ runs:
         path: |
           ${{ env.WOPEE_AGENT_WORK_DIR }}/test-results
           ${{ env.WOPEE_AGENT_WORK_DIR }}/playwright-report
+          /tmp/proxy.out
+          /tmp/chrome.out
+          /tmp/socat-proxy.out
+          /tmp/socat-viewer.out
+        if-no-files-found: ignore
         retention-days: 1
 
     - name: Export Test Report to WOPEE_AGENT_REPORT


### PR DESCRIPTION
## Summary

When the interactive flow (`AGENT_MODE=interactive`) fails, the stdout streams of `chrome`, `cdp-session-proxy`, and the socat port forwarders live in `/tmp` on the runner and are lost when the job ends. Append them to the existing `playwright-results` artifact so the next interactive-flow regression is debuggable without SSH'ing into a runner.

Motivated by the recent debugging round where the proxy was running fine but `/tmp/proxy.out` was inaccessible after the run.

\`if-no-files-found: ignore\` keeps non-interactive dispatches (where these files don't exist) from failing the upload step.

## Test plan

- [ ] Fire a fresh interactive dispatch from CMD and confirm the \`playwright-results\` artifact contains \`proxy.out\`, \`chrome.out\`, and the two \`socat-*.out\` files.
- [ ] Fire a non-interactive dispatch and confirm the upload step still succeeds (only the existing test-results/playwright-report paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)