### PR TITLE
fix: skip fallback post-process when already confirmed and retry notification curls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -379,7 +379,8 @@ runs:
         EOF
           )
 
-          curl --request POST --max-time 10 \
+          curl --request POST --max-time 20 \
+            --retry 3 --retry-delay 2 \
             --header 'content-type: application/json' \
             --header 'api_key: ${{ env.WOPEE_API_KEY }}' \
             --url '${{ env.WOPEE_API_URL }}' \
@@ -438,6 +439,15 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+
+        # pw-agent writes this marker only after the server confirmed post-processing.
+        # If it exists, the suite is already finalized (the agent step may still have
+        # failed for other reasons) — a second error:true post-process would wrongly
+        # mark it failed/stopped.
+        if [ -f "${WOPEE_AGENT_WORK_DIR:-}/test-results/.wopee-postprocess-ok" ]; then
+          echo "Post-process already confirmed by the agent; skipping fallback"
+          exit 0
+        fi
 
         if [ -z "${WOPEE_API_URL:-}" ] || [ -z "${WOPEE_API_KEY:-}" ]; then
           echo "WARNING: WOPEE_API_URL or WOPEE_API_KEY is missing; skipping fallback post-process"
@@ -510,7 +520,8 @@ runs:
         fi
 
         curl --fail-with-body --silent --show-error \
-          --request POST \
+          --request POST --max-time 30 \
+          --retry 3 --retry-delay 2 \
           --header "content-type: application/json" \
           --header "api_key: ${WOPEE_API_KEY}" \
           --url "${WOPEE_API_URL}" \


### PR DESCRIPTION
## Summary

run-agent leg of wopee-continental/pilot#16 (analysis stuck in "running"). Closes #16.

pw-agent now fails its step when the post-process mutation was never confirmed (autonomous-testing/pw-agent#243), which makes the fallback step here fire in a new case: agent succeeded, post-process already landed, but the step failed for another reason. Without a guard, that would send a duplicate `error:true` post-process and wrongly fail an already-finalized suite.

## Changes

- Fallback post-process step exits early when `${WOPEE_AGENT_WORK_DIR}/test-results/.wopee-postprocess-ok` exists (written by pw-agent only after the server confirmed post-processing). Backward compatible: older pw-agent versions write no marker, so behavior is unchanged for them.
- `notify_cmd_on_cancel` trap curl: `--max-time 10` → `20`, plus `--retry 3 --retry-delay 2`; the fallback curl gets the same retries — the pilot environment has documented network flakiness (wopee-continental/pilot#20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)